### PR TITLE
Update powershell_malicious_commandlets.yml

### DIFF
--- a/rules/windows/powershell/powershell_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_malicious_commandlets.yml
@@ -112,6 +112,7 @@ detection:
             - "*Invoke-SMBScanner*"
             - "*Invoke-Mimikittenz*"
             - "*Invoke-AllChecks*"
+            - "*Find-PotentiallyCrackableAccounts*"
             - "*Invoke-Kerberoast*"
     false_positives:
         - Get-SystemDriveInfo  # http://bheltborg.dk/Windows/WinSxS/amd64_microsoft-windows-maintenancediagnostic_31bf3856ad364e35_10.0.10240.16384_none_91ef7543a4514b5e/CL_Utility.ps1


### PR DESCRIPTION
Find-PotentiallyCrackableAccounts for SPN are vulnerable to offline brute-forcing and they are often (by default) configured with weak password and encryption (RC4-HMAC).
ref: https://www.cyberark.com/resources/blog/service-accounts-weakest-link-in-the-chain

Invoke-Kerberoast for Kerberoasting without mimikatz from powershell empire.
ref: https://www.harmj0y.net/blog/powershell/kerberoasting-without-mimikatz/